### PR TITLE
修改报错的时候，提示用brew安装pngquant的代码中pngquant的拼写错误

### DIFF
--- a/lib/pngquant/exec.js
+++ b/lib/pngquant/exec.js
@@ -31,7 +31,7 @@ exports.run = function*(base, image){
   try {
     stdout = yield exec(cmd, {cwd: base});
   } catch(e) {
-    logger.success('生成png8图片失败，需要手动安装pngquant：brew install pngqunat');
+    logger.success('生成png8图片失败，需要手动安装pngquant：brew install pngquant');
     return false;
   }
 


### PR DESCRIPTION
简单修复个单词拼写错误，我当时就是直接复制了提示的代码，然后怎么也安装不了。所以觉得还是有必要修复这个单词拼写错误的
